### PR TITLE
Attempt to fix the CLA bot

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -26,9 +26,9 @@ jobs:
           PERSONAL_ACCESS_TOKEN : ${{ secrets.PERSONAL_ACCESS_TOKEN }}
         with:
           path-to-signatures: 'signatures/version1/cla.json'
-          path-to-document: 'https://github.com/Kaszanas/FE_ClipIT_leptos/blob/master/CLA.md' # e.g. a CLA or a DCO document
+          path-to-document: 'https://github.com/Kaszanas/SC2DatasetPreparator/blob/dev/CLA.md' # e.g. a CLA or a DCO document
           # branch should not be protected
-          branch: 'master'
+          branch: 'dev'
           allowlist: Kaszanas,bot*
 
          #below are the optional inputs - If the optional inputs are not given, then default values will be taken


### PR DESCRIPTION
Pointed the CLA link to the right repo and branch. Changed the branch to record CLA agreements from master (which doesn't exist) to dev, which should be most up-to-date.