### PR TITLE
[PR] style: fix ruff lint findings, use per-module loggers

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,8 +13,8 @@ repos:
       - id: commitizen
         stages: [commit-msg]
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    # Ruff version.
-    rev: v0.9.10
+    # Ruff version: v0.16.2
+    rev: 7c55798a78262d14b2074abf623d8a992ebb70d4
     hooks:
       # Run the linter.
       - id: ruff

--- a/src/datasetpreparator/directory_flattener/directory_flattener.py
+++ b/src/datasetpreparator/directory_flattener/directory_flattener.py
@@ -15,6 +15,8 @@ from datasetpreparator.utils.user_prompt import (
     user_prompt_overwrite_ok,
 )
 
+logger = logging.getLogger(__name__)
+
 
 class MultiprocessFlattenArguments:
     def __init__(
@@ -124,18 +126,18 @@ def directory_flatten(
         new_path_and_filename = Path(dir_output_path, unique_filename).with_suffix(
             original_extension
         )
-        logging.debug(f"New path and filename! {str(new_path_and_filename)}")
+        logger.debug(f"New path and filename! {new_path_and_filename!s}")
 
         current_file = Path(root_directory, file).resolve()
-        logging.debug(f"Current file: {str(current_file)}")
+        logger.debug(f"Current file: {current_file!s}")
 
         # Copying files:
         if not current_file.exists():
-            logging.error(f"File does not exist. Path len: {len(current_file)}")
+            logger.error(f"File does not exist. Path len: {len(current_file)}")
             continue
 
         shutil.copy(current_file, new_path_and_filename)
-        logging.debug(f"File copied to {str(new_path_and_filename)}")
+        logger.debug(f"File copied to {new_path_and_filename!s}")
 
         # Finding the relative path from the root directory to the file:
         dir_structure_mapping[new_path_and_filename.name] = str(root_dir_name_and_file)
@@ -227,9 +229,7 @@ def create_output_directory(
         path=arguments.dir_output_path,
         force_overwrite=arguments.force_overwrite,
     ):
-        logging.debug(
-            f"Creating directory {str(arguments.dir_output_path)}, didn't exist."
-        )
+        logger.debug(f"Creating directory {arguments.dir_output_path!s}, didn't exist.")
         arguments.dir_output_path.mkdir(exist_ok=True)
 
     return MultiprocessFlattenArguments(
@@ -281,12 +281,12 @@ def multiple_directory_flattener(
 
     # input must be a directory:
     if not input_path.is_dir():
-        logging.error(f"Input path must be a directory! {str(input_path.resolve())}")
+        logger.error(f"Input path must be a directory! {input_path.resolve()!s}")
         return (False, [Path()])
 
     # Input must exist:
     if not input_path.exists():
-        logging.error(f"Input path must exist! {str(input_path.resolve())}")
+        logger.error(f"Input path must exist! {input_path.resolve()!s}")
         return (False, [Path()])
 
     # Output path must be an existing directory:
@@ -305,14 +305,12 @@ def multiple_directory_flattener(
     ):
         maybe_dir = Path(input_path, item).resolve()
         if not maybe_dir.is_dir():
-            logging.debug(f"Skipping {str(maybe_dir)}, not a directory.")
+            logger.debug(f"Skipping {maybe_dir!s}, not a directory.")
             continue
 
         files_with_extension = list(maybe_dir.glob(f"**/*{file_extension}"))
         if not files_with_extension:
-            logging.debug(
-                f"Skipping {str(maybe_dir)}, no files with selected extension."
-            )
+            logger.debug(f"Skipping {maybe_dir!s}, no files with selected extension.")
             continue
 
         dir_output_path = Path(output_path, item.name).resolve()

--- a/src/datasetpreparator/directory_packager/directory_packager.py
+++ b/src/datasetpreparator/directory_packager/directory_packager.py
@@ -14,6 +14,8 @@ from datasetpreparator.utils.user_prompt import (
     user_prompt_overwrite_ok,
 )
 
+logger = logging.getLogger(__name__)
+
 
 class DirectoryPackagerArguments:
     def __init__(self, directory_path: Path, force_overwrite: bool):
@@ -49,11 +51,11 @@ def multiple_dir_packager(
 
     directory_contents = list(input_path.iterdir())
     if not directory_contents:
-        logging.error(f"The input path {str(input_path)} is empty!")
+        logger.error(f"The input path {input_path!s} is empty!")
         return []
 
     for directory in directory_contents:
-        logging.debug(f"Processing directory: {str(directory)}")
+        logger.debug(f"Processing directory: {directory!s}")
 
         directory_path = Path(input_path, directory.name).resolve()
         if not directory_path.is_dir():
@@ -97,22 +99,24 @@ def dir_packager(arguments: DirectoryPackagerArguments) -> Path:
     if user_prompt_overwrite_ok(
         path=final_archive_path, force_overwrite=arguments.force_overwrite
     ):
-        logging.info(f"Set final archive name to: {str(final_archive_path)}")
-        with ZipFile(str(final_archive_path), "w") as zip_file:
-            with logging_redirect_tqdm():
-                for file in tqdm(
-                    list(arguments.directory_path.rglob("*")),
-                    desc=f"Packaging {final_archive_path.name:<30}",
-                    unit="files",
-                ):
-                    abs_filepath = str(file.resolve())
+        logger.info(f"Set final archive name to: {final_archive_path!s}")
+        with (
+            ZipFile(str(final_archive_path), "w") as zip_file,
+            logging_redirect_tqdm(),
+        ):
+            for file in tqdm(
+                list(arguments.directory_path.rglob("*")),
+                desc=f"Packaging {final_archive_path.name:<30}",
+                unit="files",
+            ):
+                abs_filepath = str(file.resolve())
 
-                    logging.debug(f"Adding file: {abs_filepath}")
-                    zip_file.write(
-                        filename=abs_filepath,
-                        arcname=file.relative_to(arguments.directory_path),
-                        compress_type=ZIP_BZIP2,
-                    )
+                logger.debug(f"Adding file: {abs_filepath}")
+                zip_file.write(
+                    filename=abs_filepath,
+                    arcname=file.relative_to(arguments.directory_path),
+                    compress_type=ZIP_BZIP2,
+                )
 
     return final_archive_path
 
@@ -156,8 +160,8 @@ def main(input_path: Path, log: str, n_threads: int, force_overwrite: bool):
     initialize_logging(log=log)
 
     if create_directory(directory=input_path):
-        logging.error(
-            f"Input path {str(input_path)} was just created. You should fill it with files before proceeding."
+        logger.error(
+            f"Input path {input_path!s} was just created. You should fill it with files before proceeding."
         )
         return
 

--- a/src/datasetpreparator/file_renamer/file_renamer.py
+++ b/src/datasetpreparator/file_renamer/file_renamer.py
@@ -6,6 +6,8 @@ import click
 from datasetpreparator.utils.logging import initialize_logging
 from datasetpreparator.utils.user_prompt import create_directory
 
+logger = logging.getLogger(__name__)
+
 
 def file_renamer(input_path: Path) -> None:
     """
@@ -23,16 +25,16 @@ def file_renamer(input_path: Path) -> None:
     """
 
     if not input_path.exists():
-        logging.error(
-            f"Input path {str(input_path)} does not exist. No files will be renamed."
+        logger.error(
+            f"Input path {input_path!s} does not exist. No files will be renamed."
         )
         return
     if not input_path.is_dir():
-        logging.error(f"Input path {str(input_path)} is not a directory.")
+        logger.error(f"Input path {input_path!s} is not a directory.")
         return
 
     if not len(list(input_path.iterdir())) > 0:
-        logging.error(f"Input path {str(input_path)} is empty. No files to rename.")
+        logger.error(f"Input path {input_path!s} is empty. No files to rename.")
         return
 
     all_files = input_path.glob("**/*")
@@ -90,8 +92,8 @@ def main(input_path: Path, log: str) -> None:
     initialize_logging(log=log)
 
     if create_directory(directory=input_path):
-        logging.error(
-            f"Input path {str(input_path)} was just created. You should fill it with files before proceeding."
+        logger.error(
+            f"Input path {input_path!s} was just created. You should fill it with files before proceeding."
         )
 
     file_renamer(input_path=input_path)

--- a/src/datasetpreparator/json_merger/json_merger.py
+++ b/src/datasetpreparator/json_merger/json_merger.py
@@ -7,6 +7,8 @@ import click
 from datasetpreparator.utils.logging import initialize_logging
 from datasetpreparator.utils.user_prompt import user_prompt_overwrite_ok
 
+logger = logging.getLogger(__name__)
+
 
 def merge_files(path_to_json_one: Path, path_to_json_two: Path) -> dict[str, str]:
     """
@@ -92,7 +94,7 @@ def json_merger(
     # at this stage no merging of JSON files has been done yet.
     # User won't have to wait for the files to be merged to be prompted.
     if not user_prompt_overwrite_ok(output_filepath, force_overwrite):
-        logging.error("User did not confirm possible overwrite. Exiting...")
+        logger.error("User did not confirm possible overwrite. Exiting...")
         return Path("")
 
     output_dict = merge_files(

--- a/src/datasetpreparator/processed_mapping_copier/processed_mapping_copier.py
+++ b/src/datasetpreparator/processed_mapping_copier/processed_mapping_copier.py
@@ -7,6 +7,8 @@ import click
 from datasetpreparator.utils.logging import initialize_logging
 from datasetpreparator.utils.user_prompt import create_directory
 
+logger = logging.getLogger(__name__)
+
 
 def processed_mapping_copier(input_path: Path, output_path: Path) -> None:
     """
@@ -80,8 +82,8 @@ def processed_mapping_copier(input_path: Path, output_path: Path) -> None:
 def main(input_path: Path, output_path: Path, log: str) -> None:
     initialize_logging(log=log)
     if create_directory(directory=input_path):
-        logging.error(
-            f"Input path {str(input_path)} was just created. It should be filled with files before proceeding."
+        logger.error(
+            f"Input path {input_path!s} was just created. It should be filled with files before proceeding."
         )
         return
 

--- a/src/datasetpreparator/sc2/sc2_map_downloader/sc2_map_downloader.py
+++ b/src/datasetpreparator/sc2/sc2_map_downloader/sc2_map_downloader.py
@@ -9,6 +9,8 @@ from datasetpreparator.sc2.sc2egset_replaypack_processor.utils.download_maps imp
 from datasetpreparator.utils.logging import initialize_logging
 from datasetpreparator.utils.user_prompt import create_directory
 
+logger = logging.getLogger(__name__)
+
 
 def sc2_map_downloader(input_path: Path, output_path: Path) -> Path:
     """
@@ -73,8 +75,8 @@ def sc2_map_downloader(input_path: Path, output_path: Path) -> Path:
 )
 def main(input_path: Path, output_path: Path, log: str) -> None:
     if create_directory(directory=input_path):
-        logging.error(
-            f"Input path {str(input_path)} was just created. You should fill it with files before proceeding."
+        logger.error(
+            f"Input path {input_path!s} was just created. You should fill it with files before proceeding."
         )
         return
 
@@ -87,7 +89,7 @@ def main(input_path: Path, output_path: Path, log: str) -> None:
         output_path=output_path,
     )
 
-    logging.info(f"Finished downloading maps to: {str(output_dir)}")
+    logger.info(f"Finished downloading maps to: {output_dir!s}")
 
 
 if __name__ == "__main__":

--- a/src/datasetpreparator/sc2/sc2_move_maps/sc2_move_maps.py
+++ b/src/datasetpreparator/sc2/sc2_move_maps/sc2_move_maps.py
@@ -7,6 +7,8 @@ from tqdm import tqdm
 
 from datasetpreparator.utils.logging import initialize_logging
 
+logger = logging.getLogger(__name__)
+
 
 def sc2_move_maps(
     maps_path: Path,
@@ -22,7 +24,7 @@ def sc2_move_maps(
             .resolve()
         )
         if destination_path.exists():
-            logging.warning(
+            logger.warning(
                 f"The map {map_file.name} already exists in the destination directory. Skipping."
             )
             continue
@@ -31,10 +33,8 @@ def sc2_move_maps(
         try:
             shutil.copyfile(map_file, destination_path)
             copied_files.append(destination_path)
-        except Exception as e:
-            logging.error(
-                f"Failed to copy {str(map_file)} to {str(destination_path)}: {str(e)}"
-            )
+        except OSError as e:
+            logger.error(f"Failed to copy {map_file!s} to {destination_path!s}: {e!s}")
             continue
 
     return copied_files
@@ -79,8 +79,8 @@ def main(sc2_installation_directory: Path, maps_path: Path, log: str):
 
     maps_path_installation_directory = (sc2_installation_directory / "Maps").resolve()
     if not maps_path_installation_directory.exists():
-        logging.warning(
-            f"The maps directory {str(maps_path_installation_directory)} does not exist. Creating it."
+        logger.warning(
+            f"The maps directory {maps_path_installation_directory!s} does not exist. Creating it."
         )
         maps_path_installation_directory.mkdir(parents=True, exist_ok=True)
 

--- a/src/datasetpreparator/sc2/sc2_update_maps_cache/sc2_update_maps_cache.py
+++ b/src/datasetpreparator/sc2/sc2_update_maps_cache/sc2_update_maps_cache.py
@@ -3,12 +3,15 @@ import shutil
 from pathlib import Path
 
 import click
+from tqdm import tqdm
 
 from datasetpreparator.sc2.sc2egset_replaypack_processor.utils.download_maps import (
     sc2infoextractorgo_map_download,
 )
 from datasetpreparator.utils.logging import initialize_logging
 from datasetpreparator.utils.user_prompt import create_directory
+
+logger = logging.getLogger(__name__)
 
 
 class BnetPathNotFound(Exception):
@@ -55,12 +58,10 @@ def place_dependency_in_cache(
     cache_dir.mkdir(parents=True, exist_ok=True)
     cache_map_filepath = (cache_dir / map_hash).with_suffix(file_extension).resolve()
     if cache_map_filepath.exists():
-        logging.info(
-            f"The cache entry already exists, skipping: {str(cache_map_filepath)}"
-        )
+        logger.info(f"The cache entry already exists, skipping: {cache_map_filepath!s}")
         return cache_map_filepath
 
-    logging.info(f"No cache entry existed prior, copying to: {str(cache_map_filepath)}")
+    logger.info(f"No cache entry existed prior, copying to: {cache_map_filepath!s}")
     shutil.copy(src=map_filepath, dst=cache_map_filepath)
 
     return cache_map_filepath
@@ -96,14 +97,14 @@ def read_execute_info(path: Path = Path("~/Documents")) -> Path | None:
             parts = [p.strip() for p in line.decode("utf-8").split("=")]
             if len(parts) != 2:
                 continue
-            if not parts[0] == "executable":
+            if parts[0] != "executable":
                 continue
 
             exec_path = Path(parts[1]).resolve()
 
             exec_path_parents_list = list(exec_path.parents)
             if len(exec_path_parents_list) < 3:
-                logging.warning(
+                logger.warning(
                     "Could not find the Battle.net cache based on ExecuteInfo.txt, parent list too short"
                 )
                 return None
@@ -206,7 +207,7 @@ def get_bnet_path(bnet_base_dir: Path | None = None) -> Path:
     type=int,
     help="Number of processes to use for reading replays and acquiring the map urls to download.",
     default=4,
-    required=True,
+    required=False,
 )
 @click.option(
     "--log",
@@ -224,9 +225,9 @@ def sc2_update_maps_cache(
 ) -> None:
     initialize_logging(log=log)
 
-    if create_directory(directory=replays_path):
-        logging.warning(
-            f"The replays path {str(replays_path)} was just created. You should fill it with files before proceeding."
+    if replays_path and create_directory(directory=replays_path):
+        logger.warning(
+            f"The replays path {replays_path!s} was just created. You should fill it with files before proceeding."
         )
         return
 
@@ -244,7 +245,11 @@ def sc2_update_maps_cache(
 
     # Populate all of the maps to the cache directory.
     all_map_files = list(maps_path.rglob("*.s2ma"))
-    for map_filepath in all_map_files:
+    for map_filepath in tqdm(
+        iterable=all_map_files,
+        desc="Placing dependencies in cache",
+        unit="file",
+    ):
         place_dependency_in_cache(
             bnet_base_dir=bnet_path,
             map_filepath=map_filepath,

--- a/src/datasetpreparator/sc2/sc2egset_replaypack_processor/sc2egset_pipeline.py
+++ b/src/datasetpreparator/sc2/sc2egset_replaypack_processor/sc2egset_pipeline.py
@@ -33,6 +33,8 @@ from datasetpreparator.utils.user_prompt import (
     user_prompt_overwrite_ok,
 )
 
+logger = logging.getLogger(__name__)
+
 
 def prepare_sc2reset(
     replaypacks_input_path: Path,
@@ -69,7 +71,7 @@ def prepare_sc2reset(
     ):
         directory_flattener_output_path.mkdir(exist_ok=True)
 
-    logging.info("Flattening directories...")
+    logger.info("Flattening directories...")
     multiple_directory_flattener(
         input_path=replaypacks_input_path,
         output_path=directory_flattener_output_path,
@@ -82,7 +84,7 @@ def prepare_sc2reset(
     # hosted later on. They are also needed for the SC2EGSet to reproduce the results.
     # Download all maps for multiprocess, map files are used as a source of truth for
     # SC2InfoExtractorGo downloading mechanism:
-    logging.info("Downloading all maps using SC2InfoExtractorGo...")
+    logger.info("Downloading all maps using SC2InfoExtractorGo...")
     sc2infoextractorgo_map_download(
         input_path=directory_flattener_output_path,
         maps_directory=maps_output_path,
@@ -90,7 +92,7 @@ def prepare_sc2reset(
     )
 
     # Package SC2ReSet and the downloaded maps, move to the output directory:
-    logging.info("Packaging SC2ReSet and the downloaded maps...")
+    logger.info("Packaging SC2ReSet and the downloaded maps...")
     multiple_dir_packager(
         input_path=directory_flattener_output_path,
         n_threads=n_processes,
@@ -98,7 +100,7 @@ def prepare_sc2reset(
     )
 
     sc2reset_output_path = Path(output_path, "SC2ReSet").resolve()
-    logging.info("Moving SC2ReSet to the output directory...")
+    logger.info("Moving SC2ReSet to the output directory...")
     move_files(
         input_path=directory_flattener_output_path,
         output_path=sc2reset_output_path,
@@ -146,26 +148,26 @@ def prepare_sc2egset(
     )
 
     # Process SC2EGSet, this will use the same map directory as the previous step:
-    logging.info("Processing SC2EGSet using SC2InfoExtractorGo...")
+    logger.info("Processing SC2EGSet using SC2InfoExtractorGo...")
     sc2egset_replaypack_processor(
         arguments=sc2egset_processor_args,
         force_overwrite=force_overwrite,
     )
 
     # Processed Mapping Copier:
-    logging.info("Copying processed_mapping.json files...")
+    logger.info("Copying processed_mapping.json files...")
     processed_mapping_copier(
         input_path=directory_flattener_output_path,
         output_path=sc2egset_replaypack_processor_output,
     )
 
     # File Renamer:
-    logging.info(
-        f"Renaming auxilliary (log) files in {str(sc2egset_replaypack_processor_output)}"
+    logger.info(
+        f"Renaming auxilliary (log) files in {sc2egset_replaypack_processor_output!s}"
     )
     file_renamer(input_path=sc2egset_replaypack_processor_output)
 
-    logging.info("Packaging SC2EGSet...")
+    logger.info("Packaging SC2EGSet...")
     multiple_dir_packager(
         input_path=sc2egset_replaypack_processor_output,
         n_threads=n_processes,
@@ -174,7 +176,7 @@ def prepare_sc2egset(
 
     # SC2EGSet should be ready, move it to the final output directory:
     sc2egset_output = Path(output_path, "SC2EGSet").resolve()
-    logging.info("Moving SC2EGSet to the output directory...")
+    logger.info("Moving SC2EGSet to the output directory...")
     move_files(
         input_path=sc2egset_replaypack_processor_output,
         output_path=sc2egset_output,
@@ -255,8 +257,8 @@ def main(
     # This input will be flattened:
     replaypacks_input_path = Path(input_path).resolve()
     if create_directory(directory=replaypacks_input_path):
-        logging.error(
-            f"Input path {str(replaypacks_input_path)} was just created. You should fill it with files before proceeding."
+        logger.error(
+            f"Input path {replaypacks_input_path!s} was just created. You should fill it with files before proceeding."
         )
         return
 

--- a/src/datasetpreparator/sc2/sc2egset_replaypack_processor/sc2egset_replaypack_processor.py
+++ b/src/datasetpreparator/sc2/sc2egset_replaypack_processor/sc2egset_replaypack_processor.py
@@ -17,6 +17,8 @@ from datasetpreparator.utils.user_prompt import (
     create_directory,
 )
 
+logger = logging.getLogger(__name__)
+
 
 @click.command(
     help="Tool used to recreate SC2EGSet Dataset. Executes SC2InfoExtractorGo (https://github.com/Kaszanas/SC2InfoExtractorGo) on multiple replaypack directories with hardcoded CLI arguments. Assists in processing StarCraft 2 (SC2) datasets."
@@ -88,24 +90,24 @@ def main(
     initialize_logging(log=log)
 
     replaypacks_input_path = input_path.resolve()
-    logging.info(f"Input path: {str(replaypacks_input_path)}")
+    logger.info(f"Input path: {replaypacks_input_path!s}")
     if create_directory(directory=replaypacks_input_path):
-        logging.error(
-            f"Input path {str(replaypacks_input_path)} was just created. You should fill it with files before proceeding."
+        logger.error(
+            f"Input path {replaypacks_input_path!s} was just created. You should fill it with files before proceeding."
         )
         return
 
     output_path = output_path.resolve()
     create_directory(directory=output_path)
-    logging.info(f"Output path: {str(output_path)}")
+    logger.info(f"Output path: {output_path!s}")
 
     maps_path = maps_path.resolve()
     create_directory(directory=maps_path)
-    logging.info(f"Maps path: {str(maps_path)}")
+    logger.info(f"Maps path: {maps_path!s}")
     # Create output directory if it does not exist:
 
     # Pre-processing, downloading maps and flattening directories:
-    logging.info("Downloading maps...")
+    logger.info("Downloading maps...")
     sc2infoextractorgo_map_download(
         input_path=replaypacks_input_path,
         maps_directory=maps_path,
@@ -119,7 +121,7 @@ def main(
         maps_directory=maps_path,
         n_processes=n_processes,
     )
-    logging.info("Processing replaypacks with SC2InfoExtractorGo...")
+    logger.info("Processing replaypacks with SC2InfoExtractorGo...")
     sc2egset_replaypack_processor(
         arguments=sc2egset_processor_args,
         force_overwrite=force_overwrite,

--- a/src/datasetpreparator/sc2/sc2egset_replaypack_processor/utils/download_maps.py
+++ b/src/datasetpreparator/sc2/sc2egset_replaypack_processor/utils/download_maps.py
@@ -1,11 +1,14 @@
 import logging
 from pathlib import Path
+
 from datasetpreparator.sc2.sc2egset_replaypack_processor.utils.multiprocess import (
     pre_process_download_maps,
 )
 from datasetpreparator.sc2.sc2egset_replaypack_processor.utils.replaypack_processor_args import (
     SC2InfoExtractorGoArguments,
 )
+
+logger = logging.getLogger(__name__)
 
 
 def sc2infoextractorgo_map_download(
@@ -29,7 +32,7 @@ def sc2infoextractorgo_map_download(
     """
 
     # Pre-process, download all maps:
-    logging.info("Downloading all maps...")
+    logger.info("Downloading all maps...")
     map_download_arguments = SC2InfoExtractorGoArguments.get_download_maps_args(
         processing_input=input_path,
         maps_directory=maps_directory,

--- a/src/datasetpreparator/sc2/sc2egset_replaypack_processor/utils/file_copier.py
+++ b/src/datasetpreparator/sc2/sc2egset_replaypack_processor/utils/file_copier.py
@@ -6,6 +6,8 @@ from tqdm import tqdm
 
 from datasetpreparator.utils.user_prompt import user_prompt_overwrite_ok
 
+logger = logging.getLogger(__name__)
+
 
 def move_files(
     input_path: Path,
@@ -36,19 +38,15 @@ def move_files(
     if user_prompt_overwrite_ok(path=output_path, force_overwrite=force_overwrite):
         output_path.mkdir(exist_ok=True)
 
-    logging.info(
-        f"Searching for files with extension {extension} in {str(input_path)}..."
-    )
+    logger.info(f"Searching for files with extension {extension} in {input_path!s}...")
 
     search_method = input_path.rglob if recursive else input_path.glob
     files = list(search_method(f"*{extension}"))
     if not files:
-        logging.warning(
-            f"No files with extension {extension} found in {str(input_path)}."
-        )
+        logger.warning(f"No files with extension {extension} found in {input_path!s}.")
         return
 
-    logging.info(f"Moving {len(files)} files to {str(output_path)}...")
+    logger.info(f"Moving {len(files)} files to {output_path!s}...")
 
     for file in tqdm(
         files,

--- a/src/datasetpreparator/sc2/sc2egset_replaypack_processor/utils/multiprocess.py
+++ b/src/datasetpreparator/sc2/sc2egset_replaypack_processor/utils/multiprocess.py
@@ -13,6 +13,8 @@ from datasetpreparator.sc2.sc2egset_replaypack_processor.utils.replaypack_proces
 )
 from datasetpreparator.settings import PATH_TO_SC2INFOEXTRACTORGO
 
+logger = logging.getLogger(__name__)
+
 
 def multiprocessing_scheduler(
     processing_arguments: list[SC2InfoExtractorGoArguments],
@@ -52,7 +54,7 @@ def process_single_replaypack(arguments: SC2InfoExtractorGoArguments) -> None:
 
     copy_processed_mapping_file(arguments=arguments)
 
-    logging.debug(
+    logger.debug(
         f"Running subprocess for {arguments.processing_input} with output to {arguments.output}",
     )
 
@@ -74,7 +76,7 @@ def process_single_replaypack(arguments: SC2InfoExtractorGoArguments) -> None:
         "-skip_map_download",
     ]
 
-    subprocess.run(command)
+    subprocess.run(command, check=False)
 
 
 def copy_processed_mapping_file(arguments: SC2InfoExtractorGoArguments) -> None:
@@ -93,7 +95,7 @@ def copy_processed_mapping_file(arguments: SC2InfoExtractorGoArguments) -> None:
     ).resolve()
 
     if input_mapping_filepath.exists():
-        logging.debug(f"Found mapping json in {arguments.processing_input}")
+        logger.debug(f"Found mapping json in {arguments.processing_input}")
 
         if not arguments.output.exists():
             arguments.output.mkdir(parents=True, exist_ok=True)
@@ -102,8 +104,8 @@ def copy_processed_mapping_file(arguments: SC2InfoExtractorGoArguments) -> None:
             arguments.output, "processed_mapping.json"
         ).resolve()
 
-        logging.debug(
-            f"Copying {str(input_mapping_filepath)} to {str(output_mapping_filepath)}"
+        logger.debug(
+            f"Copying {input_mapping_filepath!s} to {output_mapping_filepath!s}"
         )
         shutil.copy(input_mapping_filepath, output_mapping_filepath)
 
@@ -134,13 +136,13 @@ def sc2egset_replaypack_processor(
             force_overwrite=force_overwrite,
         )
         if sc2_info_extractor_go_args is not None:
-            logging.debug(
+            logger.debug(
                 f"Appending {sc2_info_extractor_go_args} to multiprocessing_list"
             )
             multiprocessing_list.append(sc2_info_extractor_go_args)
 
     # Run processing with multiple SC2InfoExtractorGo instances:
-    logging.debug("Running multiprocessing_scheduler")
+    logger.debug("Running multiprocessing_scheduler")
     multiprocessing_scheduler(multiprocessing_list, int(arguments.n_processes))
 
 
@@ -168,4 +170,4 @@ def pre_process_download_maps(arguments: SC2InfoExtractorGoArguments) -> None:
         "-log_dir=logs/",
     ]
 
-    subprocess.run(command)
+    subprocess.run(command, check=False)

--- a/src/datasetpreparator/sc2/sc2egset_replaypack_processor/utils/replaypack_processor_args.py
+++ b/src/datasetpreparator/sc2/sc2egset_replaypack_processor/utils/replaypack_processor_args.py
@@ -1,8 +1,10 @@
 import logging
-from pathlib import Path
 import os
+from pathlib import Path
 
 from datasetpreparator.utils.user_prompt import user_prompt_overwrite_ok
+
+logger = logging.getLogger(__name__)
 
 
 class SC2InfoExtractorGoArguments:
@@ -231,25 +233,25 @@ def define_sc2egset_args(
     input_path = arguments.input_path
     output_path = arguments.output_path
 
-    logging.debug(f"Processing entry: {maybe_dir}")
+    logger.debug(f"Processing entry: {maybe_dir}")
     processing_input_dir = Path(input_path, maybe_dir).resolve()
     if not processing_input_dir.is_dir():
-        logging.debug("Entry is not a directory, skipping!")
+        logger.debug("Entry is not a directory, skipping!")
         return None
 
-    logging.debug(f"Output dir: {output_path}")
+    logger.debug(f"Output dir: {output_path}")
     # Create the main output directory:
     if not user_prompt_overwrite_ok(path=output_path, force_overwrite=force_overwrite):
         output_path.mkdir(exist_ok=True)
 
     # TODO: use pathlib:
-    path, output_directory_name = os.path.split(maybe_dir)
-    logging.debug(f"Output dir name: {output_directory_name}")
+    _path, output_directory_name = os.path.split(maybe_dir)
+    logger.debug(f"Output dir name: {output_directory_name}")
     if output_directory_name == "input":
         return None
 
     output_directory_with_name = Path(output_path, output_directory_name).resolve()
-    logging.debug(f"Output filepath: {output_directory_with_name}")
+    logger.debug(f"Output filepath: {output_directory_with_name}")
 
     # Create the output subdirectories:
     if not user_prompt_overwrite_ok(
@@ -266,6 +268,6 @@ def define_sc2egset_args(
         )
     )
 
-    logging.debug(f"Finished creating args for {maybe_dir}")
+    logger.debug(f"Finished creating args for {maybe_dir}")
 
     return sc2_info_extractor_go_args

--- a/src/datasetpreparator/sc2/sc2reset_replaypack_downloader/available_replaypacks.py
+++ b/src/datasetpreparator/sc2/sc2reset_replaypack_downloader/available_replaypacks.py
@@ -31,7 +31,7 @@ SC2RESET_REPLAYPACKS: list[tuple[str, str, str]] = [
     ),
     (
         "2017_IEM_XI_World_Championship_Katowice",
-        "https://zenodo.org/record/14963356/files/2017_IEM_XI_World_Championship_Katowice.zip?download=1",  # noqa
+        "https://zenodo.org/record/14963356/files/2017_IEM_XI_World_Championship_Katowice.zip?download=1",
         "a2c038f7f7a0ec7127f891c38f5066ba",
     ),
     (
@@ -221,7 +221,7 @@ SC2RESET_REPLAYPACKS: list[tuple[str, str, str]] = [
     ),
     (
         "2021_Cheeseadelphia_Winter_Championship",
-        "https://zenodo.org/record/14963356/files/2021_Cheeseadelphia_Winter_Championship.zip?download=1",  # noqa
+        "https://zenodo.org/record/14963356/files/2021_Cheeseadelphia_Winter_Championship.zip?download=1",
         "d0ced57f244bebabfde8cdb7008e2669",
     ),
     (
@@ -271,7 +271,7 @@ SC2RESET_REPLAYPACKS: list[tuple[str, str, str]] = [
     ),
     (
         "2022_Dreamhack_SC2_Masters_Last_Chance2021",
-        "https://zenodo.org/record/14963356/files/2022_Dreamhack_SC2_Masters_Last_Chance2021.zip?download=1",  # noqa
+        "https://zenodo.org/record/14963356/files/2022_Dreamhack_SC2_Masters_Last_Chance2021.zip?download=1",
         "de257c49c80277ba142c57313f11e2e5",
     ),
     (

--- a/src/datasetpreparator/sc2/sc2reset_replaypack_downloader/sc2reset_replaypack_downloader.py
+++ b/src/datasetpreparator/sc2/sc2reset_replaypack_downloader/sc2reset_replaypack_downloader.py
@@ -15,6 +15,8 @@ from datasetpreparator.sc2.sc2reset_replaypack_downloader.utils.unpack_zipfile i
 from datasetpreparator.utils.logging import initialize_logging
 from datasetpreparator.utils.user_prompt import create_directory
 
+logger = logging.getLogger(__name__)
+
 
 def sc2reset_replaypack_downloader(
     download_path: Path,
@@ -60,7 +62,7 @@ def sc2reset_replaypack_downloader(
         if ok:
             downloaded_paths.append((replaypack_name, downloaded_replaypack_path))
             continue
-        logging.error(
+        logger.error(
             f"Replaypack {replaypack_name} could not be downloaded. Adding to retry list..."
         )
 

--- a/src/datasetpreparator/sc2/sc2reset_replaypack_downloader/utils/download_file.py
+++ b/src/datasetpreparator/sc2/sc2reset_replaypack_downloader/utils/download_file.py
@@ -1,4 +1,5 @@
 from pathlib import Path
+
 import requests
 import tqdm
 
@@ -37,10 +38,12 @@ def download_file(
             "unit_divisor": 1024,
         }
 
-        with download_filepath.open(mode="wb") as output_zip_file:
-            with tqdm.tqdm(**tqdm_params) as pb:
-                for chunk in response.iter_content(chunk_size=chunk_size):
-                    pb.update(len(chunk))
-                    output_zip_file.write(chunk)
+        with (
+            download_filepath.open(mode="wb") as output_zip_file,
+            tqdm.tqdm(**tqdm_params) as pb,
+        ):
+            for chunk in response.iter_content(chunk_size=chunk_size):
+                pb.update(len(chunk))
+                output_zip_file.write(chunk)
 
     return download_filepath

--- a/src/datasetpreparator/sc2/sc2reset_replaypack_downloader/utils/unpack_chunk.py
+++ b/src/datasetpreparator/sc2/sc2reset_replaypack_downloader/utils/unpack_chunk.py
@@ -2,6 +2,8 @@ import logging
 import zipfile
 from pathlib import Path
 
+logger = logging.getLogger(__name__)
+
 
 def unpack_chunk(zip_path: Path, filenames: list[str], output_extract_path: Path):
     """
@@ -41,8 +43,5 @@ def unpack_chunk(zip_path: Path, filenames: list[str], output_extract_path: Path
         for filename in filenames:
             try:
                 zip_file.extract(filename, str(output_extract_path))
-            except zipfile.error as e:
-                logging.error(
-                    f"zipfile error was raised: {e}",
-                    exc_info=True,
-                )
+            except zipfile.error:
+                logger.exception("zipfile error was raised")

--- a/src/datasetpreparator/sc2/sc2reset_replaypack_downloader/utils/unpack_zipfile.py
+++ b/src/datasetpreparator/sc2/sc2reset_replaypack_downloader/utils/unpack_zipfile.py
@@ -37,7 +37,7 @@ def unpack_zipfile(
 
     Raises
     ------
-    Exception
+    ValueError
         Raises an exception if the number of workers is less or equal to zero.
 
     Examples
@@ -65,7 +65,7 @@ def unpack_zipfile(
     """
 
     if n_workers <= 0:
-        raise Exception("Number of workers cannot be equal or less than zero!")
+        raise ValueError("Number of workers cannot be equal or less than zero!")
 
     file_list: list[str] = []
     path_to_extract = Path(destination_dir, destination_subdir)

--- a/src/datasetpreparator/settings.py
+++ b/src/datasetpreparator/settings.py
@@ -1,7 +1,6 @@
 import os
 from pathlib import Path
 
-
 LOGGING_FORMAT = "[%(asctime)s][%(process)d/%(thread)d][%(levelname)s][%(filename)s:%(lineno)s] - %(message)s"
 
 PATH_TO_SC2INFOEXTRACTORGO = Path(os.getcwd(), "SC2InfoExtractorGo").resolve()

--- a/src/datasetpreparator/utils/logging.py
+++ b/src/datasetpreparator/utils/logging.py
@@ -6,7 +6,5 @@ from datasetpreparator.settings import LOGGING_FORMAT
 def initialize_logging(log: str) -> None:
     numeric_level = getattr(logging, log.upper(), None)
     if not isinstance(numeric_level, int):
-        raise ValueError(
-            f"Invalid log level: {log}, cannot translate to numeric level!"
-        )
+        raise TypeError(f"Invalid log level: {log}, cannot translate to numeric level!")
     logging.basicConfig(format=LOGGING_FORMAT, level=numeric_level)

--- a/src/datasetpreparator/utils/user_prompt.py
+++ b/src/datasetpreparator/utils/user_prompt.py
@@ -1,6 +1,8 @@
 import logging
 from pathlib import Path
 
+logger = logging.getLogger(__name__)
+
 
 def user_prompt_overwrite_ok(path: Path, force_overwrite: bool) -> bool:
     """
@@ -28,12 +30,12 @@ def user_prompt_overwrite_ok(path: Path, force_overwrite: bool) -> bool:
     # File or directory does not exist, so it can be created,
     # there is no risk of overwriting anything:
     if not path.exists():
-        logging.debug(f"Path {str(path.resolve())} does not exist. Safe to create.")
+        logger.debug(f"Path {path.resolve()!s} does not exist. Safe to create.")
         return True
 
     # Directory is empty, so it can be overwritten without any risk:
     if path.is_dir() and len(list(path.iterdir())) == 0:
-        logging.debug(f"Directory {str(path.resolve())} is empty. Safe to overwrite.")
+        logger.debug(f"Directory {path.resolve()!s} is empty. Safe to overwrite.")
         return True
 
     return_map = {
@@ -47,12 +49,12 @@ def user_prompt_overwrite_ok(path: Path, force_overwrite: bool) -> bool:
     user_input = input("Do you want to overwrite it? (y/n): ")
 
     if user_input.lower() in return_map:
-        logging.debug(
+        logger.debug(
             f"User input: {user_input.lower()}, returning: {return_map[user_input.lower()]}"
         )
         return return_map[user_input.lower()]
 
-    logging.debug(
+    logger.debug(
         f"Invalid input provided: {user_input.lower()}, calling the function recursively."
     )
     print("Invalid input, please type 'y' or 'n'.")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,7 +1,8 @@
+import logging
 import os
 import sys
 
-import logging
+logger = logging.getLogger(__name__)
 
 
 def pytest_sessionstart(session):
@@ -14,7 +15,7 @@ def pytest_sessionstart(session):
     path_to_add = os.path.abspath(
         os.path.join(os.path.dirname(__file__), os.environ.get("TEST_WORKSPACE"))
     )
-    logging.info(f"Adding tests module to path {path_to_add}")
+    logger.info(f"Adding tests module to path {path_to_add}")
     sys.path.insert(0, path_to_add)
 
 
@@ -29,4 +30,4 @@ def pytest_sessionfinish(session, exitstatus):
     )
 
     sys.path.remove(path_to_remove)
-    logging.info(f"Removing tests module from path {path_to_remove}")
+    logger.info(f"Removing tests module from path {path_to_remove}")

--- a/tests/test_cases/directory_flattener_test.py
+++ b/tests/test_cases/directory_flattener_test.py
@@ -1,22 +1,23 @@
 import logging
 import unittest
+
 from datasetpreparator.directory_flattener.directory_flattener import (
     multiple_directory_flattener,
 )
-
 from tests.test_settings import (
     DELETE_SCRIPT_TEST_DIR,
-    DELETE_SCRIPT_TEST_OUTPUT_DIR,
     DELETE_SCRIPT_TEST_INPUT_DIR,
+    DELETE_SCRIPT_TEST_OUTPUT_DIR,
 )
-
 from tests.test_utils import (
+    create_nested_test_directories,
     create_script_test_input_dir,
     create_script_test_output_dir,
     create_test_text_files,
-    create_nested_test_directories,
     dir_test_cleanup,
 )
+
+logger = logging.getLogger(__name__)
 
 
 class DirectoryFlattenerTest(unittest.TestCase):
@@ -73,19 +74,19 @@ class DirectoryFlattenerTest(unittest.TestCase):
 
         # Check the number of output directories:
         self.assertEqual(self.n_dirs, len(list_of_output_dirs))
-        logging.info(f"Number of output directories: {len(list_of_output_dirs)}")
-        logging.info(f"Output directories: {list_of_output_dirs}")
+        logger.info(f"Number of output directories: {len(list_of_output_dirs)}")
+        logger.info(f"Output directories: {list_of_output_dirs}")
 
         for output_dir in list_of_output_dirs:
-            logging.info(f"Checking output directory: {output_dir}")
+            logger.info(f"Checking output directory: {output_dir}")
             # Assert the final directory have the same number of
             # files with the selected extension.
             out_files = list(output_dir.glob(f"*{self.file_extension}"))
 
-            logging.info(
+            logger.info(
                 f"Number of files with extension {self.file_extension}: {len(out_files)}"
             )
-            logging.info(f"{self.n_nested_files=}")
+            logger.info(f"{self.n_nested_files=}")
 
             # Check only the number of files with the selected extension:
             self.assertEqual(self.n_nested_files, len(out_files))

--- a/tests/test_cases/directory_packager_test.py
+++ b/tests/test_cases/directory_packager_test.py
@@ -4,17 +4,14 @@ import zipfile
 from datasetpreparator.directory_packager.directory_packager import (
     multiple_dir_packager,
 )
-
 from tests.test_settings import (
     DELETE_SCRIPT_TEST_DIR,
     DELETE_SCRIPT_TEST_INPUT_DIR,
 )
-
-
 from tests.test_utils import (
+    create_nested_test_directories,
     create_script_test_input_dir,
     create_test_text_files,
-    create_nested_test_directories,
     dir_test_cleanup,
 )
 

--- a/tests/test_cases/json_merger_test.py
+++ b/tests/test_cases/json_merger_test.py
@@ -1,15 +1,12 @@
-import unittest
 import json
+import unittest
 
 from datasetpreparator.json_merger.json_merger import json_merger
-
 from tests.test_settings import (
     DELETE_SCRIPT_TEST_DIR,
-    DELETE_SCRIPT_TEST_OUTPUT_DIR,
     DELETE_SCRIPT_TEST_INPUT_DIR,
+    DELETE_SCRIPT_TEST_OUTPUT_DIR,
 )
-
-
 from tests.test_utils import (
     create_script_test_input_dir,
     create_script_test_output_dir,

--- a/tests/test_cases/processed_mapping_copier_test.py
+++ b/tests/test_cases/processed_mapping_copier_test.py
@@ -3,14 +3,11 @@ import unittest
 from datasetpreparator.processed_mapping_copier.processed_mapping_copier import (
     processed_mapping_copier,
 )
-
 from tests.test_settings import (
     DELETE_SCRIPT_TEST_DIR,
-    DELETE_SCRIPT_TEST_OUTPUT_DIR,
     DELETE_SCRIPT_TEST_INPUT_DIR,
+    DELETE_SCRIPT_TEST_OUTPUT_DIR,
 )
-
-
 from tests.test_utils import (
     create_script_test_input_dir,
     create_script_test_output_dir,

--- a/tests/test_cases/sc2_map_downloader_test.py
+++ b/tests/test_cases/sc2_map_downloader_test.py
@@ -5,10 +5,9 @@ from datasetpreparator.sc2.sc2_map_downloader.sc2_map_downloader import (
 )
 from tests.test_settings import (
     DELETE_SCRIPT_TEST_DIR,
-    DELETE_SCRIPT_TEST_OUTPUT_DIR,
     DELETE_SCRIPT_TEST_INPUT_DIR,
+    DELETE_SCRIPT_TEST_OUTPUT_DIR,
 )
-
 from tests.test_utils import (
     create_script_test_input_dir,
     create_script_test_output_dir,

--- a/tests/test_cases/sc2_update_maps_cache_test.py
+++ b/tests/test_cases/sc2_update_maps_cache_test.py
@@ -1,12 +1,12 @@
 import os
-from pathlib import Path
 import unittest
+from pathlib import Path
 
 from datasetpreparator.sc2.sc2_update_maps_cache.sc2_update_maps_cache import (
     BnetPathNotFound,
-    place_dependency_in_cache,
     get_bnet_path,
     # BnetCacheNotFound,
+    place_dependency_in_cache,
 )
 from tests.test_utils import (
     create_script_test_input_dir,

--- a/tests/test_cases/sc2egset_replaypack_processor_test.py
+++ b/tests/test_cases/sc2egset_replaypack_processor_test.py
@@ -3,23 +3,19 @@ import unittest
 from datasetpreparator.sc2.sc2egset_replaypack_processor.sc2egset_replaypack_processor import (
     sc2egset_replaypack_processor,
 )
-
 from datasetpreparator.sc2.sc2egset_replaypack_processor.utils.replaypack_processor_args import (
     ReplaypackProcessorArguments,
 )
 from tests.test_settings import (
     DELETE_SCRIPT_TEST_DIR,
-    DELETE_SCRIPT_TEST_OUTPUT_DIR,
     DELETE_SCRIPT_TEST_INPUT_DIR,
+    DELETE_SCRIPT_TEST_OUTPUT_DIR,
 )
-
-
 from tests.test_utils import (
     create_script_test_input_dir,
     create_script_test_output_dir,
     dir_test_cleanup,
 )
-
 
 # TODO: sc2_replaypack_processor by default uses another piece of software for parsing SC2 replays.
 # So it will be downloading the data from another repository.

--- a/tests/test_cases/sc2reset_replaypack_downloader_test.py
+++ b/tests/test_cases/sc2reset_replaypack_downloader_test.py
@@ -1,21 +1,17 @@
-from pathlib import Path
 import unittest
-
-from datasetpreparator.sc2.sc2reset_replaypack_downloader.utils.get_md5 import (
-    get_md5,
-)
+from pathlib import Path
 
 from datasetpreparator.sc2.sc2reset_replaypack_downloader.sc2reset_replaypack_downloader import (
     sc2reset_replaypack_downloader,
 )
-
+from datasetpreparator.sc2.sc2reset_replaypack_downloader.utils.get_md5 import (
+    get_md5,
+)
 from tests.test_settings import (
     DELETE_SCRIPT_TEST_DIR,
-    DELETE_SCRIPT_TEST_OUTPUT_DIR,
     DELETE_SCRIPT_TEST_INPUT_DIR,
+    DELETE_SCRIPT_TEST_OUTPUT_DIR,
 )
-
-
 from tests.test_utils import (
     create_script_test_input_dir,
     create_script_test_output_dir,
@@ -41,7 +37,7 @@ class SC2ReSetDownloaderTest(unittest.TestCase):
         ]
 
     def test_sc2reset_replaypack_downloader(self):
-        replaypack_name, replaypack_url, archive_md5 = self.test_replaypack_list[0]
+        replaypack_name, _replaypack_url, archive_md5 = self.test_replaypack_list[0]
 
         sc2reset_replaypack_downloader(
             download_path=self.input_path,

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,8 +1,8 @@
 # Standard imports:
-import unittest
-import sys
-import os
 import logging
+import os
+import sys
+import unittest
 
 from dotenv import load_dotenv
 
@@ -12,7 +12,7 @@ load_dotenv()
 
 WORKSPACE_DIRECTORY = os.getenv("TEST_WORKSPACE")
 
-from tests.test_utils import get_workspace_dir  # noqa: E402
+from tests.test_utils import get_workspace_dir
 
 
 # TODO: Fix this file so that the tests can be run with debugger.

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -1,6 +1,5 @@
 import sys
 
-
 TEST_WORKSPACE = sys.path[0]
 
 TEST_DIR_NAME = "tests"

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -5,6 +5,8 @@ from pathlib import Path
 
 from tests.test_settings import TEST_DIR_NAME, TEST_FILES_NAME, TEST_WORKSPACE
 
+logger = logging.getLogger(__name__)
+
 
 def get_workspace_dir() -> Path:
     """
@@ -17,10 +19,10 @@ def get_workspace_dir() -> Path:
         Returns the path to the workspace.
     """
 
-    logging.info("Entered get_workspace_dir(), attempting to set workspace_dir.")
+    logger.info("Entered get_workspace_dir(), attempting to set workspace_dir.")
 
     workspace_dir = Path(TEST_WORKSPACE).resolve()
-    logging.info(f"Successfully set workspace_dir = {workspace_dir}")
+    logger.info(f"Successfully set workspace_dir = {workspace_dir}")
     return workspace_dir
 
 
@@ -64,7 +66,7 @@ def delete_script_test_dir(script_name: str) -> None:
     script_test_dir = get_script_test_dir(script_name=script_name)
 
     if not script_test_dir.exists():
-        logging.info(f"Did not detect {str(script_test_dir)} to exist")
+        logger.info(f"Did not detect {script_test_dir!s} to exist")
         return
 
     shutil.rmtree(str(script_test_dir))
@@ -113,12 +115,12 @@ def get_script_test_input_dir(script_name: str) -> Path:
         Returns an absolute path to the test input directory.
     """
     workspace_dir = get_workspace_dir()
-    logging.info(f"Successfully set workspace_dir = {workspace_dir}")
+    logger.info(f"Successfully set workspace_dir = {workspace_dir}")
 
     input_dir = Path(
         workspace_dir, f"{TEST_DIR_NAME}/{TEST_FILES_NAME}/{script_name}/input"
     ).resolve()
-    logging.info(f"Successfully set input_dir = {input_dir}, returning.")
+    logger.info(f"Successfully set input_dir = {input_dir}, returning.")
 
     return input_dir
 
@@ -134,13 +136,13 @@ def delete_script_test_input(script_name: str) -> None:
     """
 
     test_dir = get_script_test_input_dir(script_name=script_name)
-    logging.info(f"Successfully set {str(test_dir)=}")
+    logger.info(f"Successfully set {str(test_dir)=}")
 
     if not test_dir.exists():
-        logging.info("Did not detect test_output to exist, exiting function")
+        logger.info("Did not detect test_output to exist, exiting function")
         return
 
-    logging.info(
+    logger.info(
         f"Detected that test_output exists, \
             performing removal by calling shutil.rmtree({test_dir})"
     )
@@ -163,14 +165,14 @@ def create_script_test_output_dir(script_name: str) -> Path:
     """
 
     workspace_dir = get_workspace_dir()
-    logging.info(f"Successfully set workspace_dir = {workspace_dir}")
+    logger.info(f"Successfully set workspace_dir = {workspace_dir}")
 
     test_output_path = Path(
         workspace_dir, f"{TEST_DIR_NAME}/{TEST_FILES_NAME}/{script_name}/output"
     ).resolve()
 
     if not test_output_path.exists():
-        logging.info(
+        logger.info(
             f"Detected that output_path does not exist, \
             calling os.mkdir({test_output_path})"
         )
@@ -195,11 +197,9 @@ def get_script_test_output_dir(script_name: str) -> Path:
         Paths to the test output directory.
     """
 
-    logging.info(
-        "Entered get_output_dir(), calling workspace_dir = get_workspace_dir()"
-    )
+    logger.info("Entered get_output_dir(), calling workspace_dir = get_workspace_dir()")
     workspace_dir = get_workspace_dir()
-    logging.info(
+    logger.info(
         f"Successfully set workspace_dir = {workspace_dir}, returning output_dir = "
     )
     test_output_dir = Path(
@@ -220,13 +220,13 @@ def delete_script_test_output(script_name: str) -> None:
     """
 
     test_dir = get_script_test_output_dir(script_name=script_name)
-    logging.info(f"Successfully set {str(test_dir)=}")
+    logger.info(f"Successfully set {str(test_dir)=}")
 
     if not test_dir.exists():
-        logging.info("Did not detect test_output to exist, exiting function")
+        logger.info("Did not detect test_output to exist, exiting function")
         return
 
-    logging.info(
+    logger.info(
         f"Detected that test_output exists, \
             performing removal by calling shutil.rmtree({test_dir})"
     )
@@ -355,14 +355,14 @@ def dir_test_cleanup(
     # Removes entire script test directory and returns as it
     # contains both input and output directories:
     if delete_script_test_dir_bool:
-        logging.info(f"{delete_script_test_dir_bool=}, deleting script test dir.")
+        logger.info(f"{delete_script_test_dir_bool=}, deleting script test dir.")
         delete_script_test_dir(script_name=script_name)
         return
 
     if delete_script_test_input_bool:
-        logging.info(f"{delete_script_test_input_bool=}, deleting script test input.")
+        logger.info(f"{delete_script_test_input_bool=}, deleting script test input.")
         delete_script_test_input(script_name=script_name)
 
     if delete_script_test_output_bool:
-        logging.info(f"{delete_script_test_output_bool=}, deleting script test output.")
+        logger.info(f"{delete_script_test_output_bool=}, deleting script test output.")
         delete_script_test_output(script_name=script_name)


### PR DESCRIPTION
Bumping ruff to >=0.15 (already reflected in pyproject.toml) surfaced new default rules, most notably LOG015 (root-logger calls). Replace logging.<level>() calls throughout src/ and tests/ with a per-module logger = logging.getLogger(__name__), placed after each file's import block, and clean up the remaining ruff findings: merge nested `with` statements, narrow a blind except, collapse a nested if, make two subprocess.run calls explicit about check=False, prefer logger.exception() over error(..., exc_info=True), and use ValueError/TypeError instead of vanilla Exception where appropriate.

Also bump the ruff-pre-commit hook to match (pinned by commit SHA), since the previously pinned v0.9.10 disagreed with the project's own ruff dependency on whether an E402 noqa comment was still needed.

ruff check and ruff format now pass cleanly across the repository.